### PR TITLE
Potential fix for code scanning alert no. 65: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -2,6 +2,9 @@
 # Scans Docker images for OS package and application dependency vulnerabilities.
 
 name: Trivy Container Scan
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/umaarov/goat-dev/security/code-scanning/65](https://github.com/umaarov/goat-dev/security/code-scanning/65)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves checking out the repository, building a Docker image, running a vulnerability scanner, and uploading results, it requires `contents: read` to access the repository files and `security-events: write` to upload the SARIF file to the GitHub Security tab. These permissions adhere to the principle of least privilege.

The `permissions` block will be added at the root of the workflow, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
