### PR TITLE
Potential fix for code scanning alert no. 63: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2,6 +2,9 @@
 # Provides in-depth static analysis for code quality and security, with framework-aware rules.
 
 name: SonarCloud PHP Analysis
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/umaarov/goat-dev/security/code-scanning/63](https://github.com/umaarov/goat-dev/security/code-scanning/63)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves checking out the repository and performing a SonarCloud scan, the minimal required permissions are `contents: read` for accessing the repository's contents and `pull-requests: write` if the workflow interacts with pull requests. The `permissions` block will be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
