### PR TITLE
Potential fix for code scanning alert no. 64: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,4 +1,6 @@
 name: ESLint
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/umaarov/goat-dev/security/code-scanning/64](https://github.com/umaarov/goat-dev/security/code-scanning/64)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only needs to read the repository contents to run ESLint, we will set `contents: read`. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

The `permissions` block will be added after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
